### PR TITLE
Update .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,5 @@
 version: "2"
 plugins:
-  bundler-audit:
-    enabled: true
   flog:
     enabled: true
   reek:


### PR DESCRIPTION
Hey there. Because there is no `gemfile.lock` in this repo, the `bundler-audit` build failed -- causing the entire Code Climate build to fail, which you can see here: https://codeclimate.com/github/semlogr/semlogr-rack/builds/6

Disabling `bundler-audit` should allow the build to complete.